### PR TITLE
Opt into suppress_warnings (marimo-book 0.1.4) — fix ICA slider placement

### DIFF
--- a/book.yml
+++ b/book.yml
@@ -29,6 +29,17 @@ launch_buttons:
   github: true
   download: true
 
+# Run `marimo export` with PYTHONWARNINGS=ignore so library warnings
+# (numpy / nltools / pandas deprecation notices, etc.) don't surface
+# as visible stderr blocks in cell output. Also fixes the precompute
+# slider's inline placement: when warning text differs across re-exports,
+# the diff detector flags upstream cells (data load, filter+smooth) as
+# "reactive" and the slider mounts inline with the wrong cell — the
+# brain viewer ends up far below the slider. Suppressing warnings makes
+# those cell outputs deterministic, so only the actual viewer is flagged.
+defaults:
+  suppress_warnings: true
+
 # Google Analytics — GA4 Measurement ID for dartbrains.org.
 # (The legacy UA-138270939-1 Universal Analytics property was retired
 # by Google on 2023-07-01; this is its GA4 successor.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ build = [
 
 [dependency-groups]
 build = [
-    "marimo-book>=0.1.3",
+    "marimo-book>=0.1.4",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ requires-dist = [
     { name = "datasets", specifier = ">=4.8.4" },
     { name = "huggingface-hub", extras = ["cli", "hf-xet"], specifier = ">=1.8.0" },
     { name = "ipyniivue", specifier = ">=2.4.4" },
-    { name = "marimo", specifier = ">=0.21.1" },
+    { name = "marimo", specifier = ">=0.23.3" },
     { name = "marimo-book", marker = "extra == 'build'" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "nbformat" },
@@ -568,7 +568,7 @@ requires-dist = [
 provides-extras = ["build"]
 
 [package.metadata.requires-dev]
-build = [{ name = "marimo-book", specifier = ">=0.1.3" }]
+build = [{ name = "marimo-book", specifier = ">=0.1.4" }]
 
 [[package]]
 name = "dartbrains-tools"
@@ -1467,7 +1467,7 @@ wheels = [
 
 [[package]]
 name = "marimo-book"
-version = "0.1.3"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1484,9 +1484,9 @@ dependencies = [
     { name = "typer" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/ba/17d07538e3bb83850ce3a84a4c54317bc5f4cb727aaf42cd764b57e20a60/marimo_book-0.1.3.tar.gz", hash = "sha256:662fb4fb342b1e736d2ac34a1049c4460ff9281f6a907efdac2f4027eb59614d", size = 151345, upload-time = "2026-04-27T12:19:04.767Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/f5/80f3d66acb17919887cbae8311071b558adc3eab15b5648f1b72d8f54370/marimo_book-0.1.4.tar.gz", hash = "sha256:03082d8e4282fecb91883be11fd81559ed46320edaecfb30bcc4ec29815331f3", size = 153605, upload-time = "2026-04-27T18:22:32.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/90/c5f237ad70526d3ea3982f80ef39bf21cdcb749e721f059c0ec8de82605f/marimo_book-0.1.3-py3-none-any.whl", hash = "sha256:7c11bd51eea8c339e53348f83b68a91f646a9caa4e392ba28d2a4eacdf823834", size = 77336, upload-time = "2026-04-27T12:19:03.011Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/c6cf383f3d0f927f1c17f14083d0764cb1bf24bdad2db27036230d5e62a0/marimo_book-0.1.4-py3-none-any.whl", hash = "sha256:732146bc9cfcf75b6f050e8891428c98e6cf8d6453579fd7fd2cf6b8c76915c2", size = 78092, upload-time = "2026-04-27T18:22:30.519Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

The ICA chapter's precompute slider on dartbrains.org/ICA/ was rendering ~2100px above the brain viewer it controls — slider at y=1229 but the brain plot at y=3364. Investigated via playwright on the live site:

- Cells flagged \`data-precompute-cell\` for \`component_slider\`: **6, 8, 12, 13**
- Cell 6: \`data = Brain_Data(...)\` — emits an \`nltools\` \`UserWarning\` to stderr
- Cell 8: \`mo.persistent_cache + filter + smooth\` — cache-state-dependent stderr
- Cells 12, 13: the actual slider widget + brain viewer (the only true downstream cells)

Neither cell 6 nor cell 8 references \`component_slider.value\` — they're false positives. The precompute pipeline's diff detector compares **all** output (display + stdout + stderr) and any non-deterministic stderr across re-exports flags the cell as reactive. The slider is then placed inline with cell 6 (the *first* reactive cell), which is far up the page.

## Fix

\`marimo-book\` 0.1.4 (released today) adds a \`defaults.suppress_warnings\` flag that runs the export subprocess with \`PYTHONWARNINGS=ignore\`. With warnings silenced at the kernel level:

- Cells 6 and 8 produce identical output across re-exports → no longer flagged as downstream
- The slider mounts inline with cell 12 (the actual viewer)
- Bonus: rendered output is much cleaner — no more \`/home/runner/.../UserWarning: ...\` blocks scattered between plots

## Changes

- \`pyproject.toml\`: \`marimo-book>=0.1.3\` → \`>=0.1.4\` (build dep group)
- \`uv.lock\`: refresh
- \`book.yml\`: add \`defaults: { suppress_warnings: true }\` with a comment explaining the precompute-positioning rationale

## Follow-up (separate)

The deeper engine fix is to make the precompute diff detector ignore stderr stream output (only display + stdout matter for "is this cell downstream"). That's a marimo-book change for a future release; opens an issue.

## Test plan

- [ ] CI builds successfully on this branch
- [ ] After merge + deploy, navigate to dartbrains.org/ICA/ and confirm the Component slider sits directly above the brain viewer (within ~50px), not 2100px above it
- [ ] No nltools UserWarning blocks visible in rendered cell output

🤖 Generated with [Claude Code](https://claude.com/claude-code)