### PR TITLE
Fix MR_Physics image 404s on deploy

### DIFF
--- a/content/MR_Physics.py
+++ b/content/MR_Physics.py
@@ -47,6 +47,7 @@ def _():
     import marimo as mo
     import numpy as np
     import plotly.graph_objects as go
+    from pathlib import Path
     from plotly.subplots import make_subplots
     from dartbrains_tools.mr_simulations import (
         GAMMA_H, GAMMA, TISSUE_PROPERTIES,
@@ -65,12 +66,22 @@ def _():
         SpinEnsembleWidget, EncodingWidget, KSpaceWidget, ConvolutionWidget,
     )
 
+    # Resolve IMG_DIR relative to book.yml so image paths work on every
+    # build host (locally + GitHub Actions runners). Hardcoded absolute
+    # paths get baked into the rendered HTML and 404 on the deployed site.
+    _ROOT = next(
+        p for p in (Path.cwd(), *Path.cwd().resolve().parents)
+        if (p / "book.yml").exists()
+    )
+    IMG_DIR = _ROOT / "images" / "signal_generation"
+
     return (
         CompassWidget,
         ConvolutionWidget,
         EncodingWidget,
         GAMMA,
         GAMMA_H,
+        IMG_DIR,
         KSpaceWidget,
         NetMagnetizationWidget,
         PrecessionWidget,
@@ -336,8 +347,8 @@ def _(mo):
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.image("/Users/lukechang/Github/dartbrains/images/signal_generation/b0.png")
+def _(IMG_DIR, mo):
+    mo.image(str(IMG_DIR / "b0.png"))
     return
 
 
@@ -1102,8 +1113,8 @@ def _(mo):
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.image("/Users/lukechang/Github/dartbrains/images/signal_generation/spin_echo_pulse_sequence.svg")
+def _(IMG_DIR, mo):
+    mo.image(str(IMG_DIR / "spin_echo_pulse_sequence.svg"))
     return
 
 
@@ -1142,8 +1153,8 @@ def _(mo):
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.image("/Users/lukechang/Github/dartbrains/images/signal_generation/gradient_echo_pulse_sequence.svg")
+def _(IMG_DIR, mo):
+    mo.image(str(IMG_DIR / "gradient_echo_pulse_sequence.svg"))
     return
 
 


### PR DESCRIPTION
## Why

Three \`mo.image()\` calls in \`content/MR_Physics.py\` had **hardcoded absolute paths from the authoring machine**:

\`\`\`python
mo.image(\"/Users/lukechang/Github/dartbrains/images/signal_generation/b0.png\")
\`\`\`

These almost certainly came from drag-and-drop in \`marimo edit\`. The path doesn't exist on the GitHub Actions runner, so marimo's image renderer falls through to the data-URL fallback, fails to open the file, and returns the original string unchanged — which ships to the browser as \`<img src=\"/Users/lukechang/...\">\` and 404s.

Browser console on https://dartbrains.org/MR_Physics/ shows:

\`\`\`
GET https://dartbrains.org/Users/lukechang/Github/dartbrains/images/signal_generation/b0.png  404
GET https://dartbrains.org/Users/lukechang/Github/dartbrains/images/signal_generation/spin_echo_pulse_sequence.svg  404
GET https://dartbrains.org/Users/lukechang/Github/dartbrains/images/signal_generation/gradient_echo_pulse_sequence.svg  404
\`\`\`

## Fix

Use the same \`IMG_DIR = _ROOT / \"images\" / \"signal_generation\"\` pattern as the other dartbrains notebooks (\`Group_Analysis.py\`, \`Parcellations.py\`, etc.). \`_ROOT\` is computed at build time from \`book.yml\`'s location, so the path resolves to wherever the runner cloned the repo, the file exists, and \`mo.image()\` embeds it as a base64 data URL into the rendered HTML.

Affected cells: lines 340 (b0.png), 1106 (spin_echo_pulse_sequence.svg), 1146 (gradient_echo_pulse_sequence.svg). All 3 source files exist in \`images/signal_generation/\`.

## Test plan

- [ ] CI builds successfully (\`marimo-book build -b book.yml --strict\`)
- [ ] After merge + deploy, view-source on dartbrains.org/MR_Physics/ shows \`<img src=\"data:image/png;base64,...\">\` and \`<img src=\"data:image/svg+xml;...\">\` instead of \`/Users/lukechang/...\` paths
- [ ] No image-path 404s in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)