### PR TITLE
CI: cache marimo-book build artifacts between deploys

### DIFF
--- a/.github/workflows/deploy-marimo-book.yml
+++ b/.github/workflows/deploy-marimo-book.yml
@@ -33,6 +33,25 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-groups
 
+      # Restore the marimo-book build cache so unchanged chapters skip
+      # re-rendering. The cache is keyed on content/, book.yml, and
+      # uv.lock — any of those changing cuts a fresh cache. restore-keys
+      # falls back to the most recent partial-match cache so even fresh
+      # keys start warm; BuildCache then validates each entry against
+      # current source hashes and re-renders only what's drifted.
+      #
+      # First build after this step lands pays full cold-build cost;
+      # subsequent unmodified-content builds drop to ~1-2 min.
+      # Heaviest chapters (ICA, Connectivity) are the big wins — their
+      # cold renders are 2-12 minutes each.
+      - name: Restore marimo-book build cache
+        uses: actions/cache@v4
+        with:
+          path: .marimo_book_cache
+          key: mb-${{ runner.os }}-${{ hashFiles('content/**', 'book.yml', 'uv.lock') }}
+          restore-keys: |
+            mb-${{ runner.os }}-
+
       - name: Validate book.yml
         run: uv run marimo-book check
 


### PR DESCRIPTION
## Why

Today every push to \`v2-marimo-migration\` / \`master\` pays the full ~15 min cold-build cost. ICA alone precomputes 10 brain renders (~2 min); Connectivity precomputes 41 widget combinations (~12 min); other chapters add a few more minutes between them. None of that work needs to be redone when you push a typo fix.

The marimo-book preprocessor already maintains a content-addressed cache at \`.marimo_book_cache/\` keyed on:

- each notebook's SHA-256 source hash
- a digest of the \`book.yml\` fields that affect rendering
- the cache schema version

Hits skip the full marimo export + rendering pipeline entirely. The only reason it doesn't help in CI is that every runner starts on a fresh filesystem with no cache.

## Fix

\`actions/cache@v4\` keyed on \`hashFiles('content/**', 'book.yml', 'uv.lock')\`:

- **Exact-match restore**: only chapters whose source/config drifted re-render. Typical PR build drops from ~15 min to ~1-2 min.
- **\`restore-keys\` fallback**: even when the key is fresh (e.g. a \`book.yml\` edit), the most recent partial-match cache is restored. \`BuildCache\` then validates each entry against current source hashes per file, re-rendering only what's drifted.
- **Per-OS scoping**: \`runner.os\` in the key prevents the hit-set from crossing runner-OS boundaries (matters for any system-dep-sensitive output like libcairo social cards).

Per-branch scoped with default-branch fallback, so PR builds warm-start from \`master\`'s cache and merging back populates \`master\`'s cache for the next deploy.

## Expected impact

| Build scenario | Without cache | With cache |
|---|---|---|
| First build after merge (cold) | ~15 min | ~15 min |
| Edit one chapter, push | ~15 min | ~1-2 min |
| Edit prose-only \`.md\` page | ~15 min | ~30 s |
| Bump \`marimo-book\` in pyproject | ~15 min | ~15 min (key changes) |
| Merge PR to master | ~15 min | ~1-2 min (warm from PR cache) |

## Test plan

- [ ] First push after merge: full build runs, cache saves at end of run
- [ ] Subsequent push that touches one chapter: \`pages_cached\` count in build report shows N-1 of N pages cached
- [ ] Bumping \`marimo-book\` version in \`pyproject.toml\`: cache invalidates appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)