### PR TITLE
Move dartbrains_tools import out of Signal_Processing setup block

### DIFF
--- a/content/Signal_Processing.py
+++ b/content/Signal_Processing.py
@@ -13,8 +13,6 @@ with app.setup(hide_code=True):
     from scipy.special import gamma as gamma_func
     from scipy.signal import butter, filtfilt, freqz, sosfreqz
 
-    from dartbrains_tools.notebook_utils import youtube
-
     _ROOT = next(p for p in (Path.cwd(), *Path.cwd().resolve().parents) if (p / "book.yml").exists())
     IMG_DIR = _ROOT / "images" / "signal_processing"
 
@@ -30,6 +28,21 @@ with app.setup(hide_code=True):
 
     def rad_to_hz(w, fs):
         return (w * fs) / (2 * np.pi)
+
+
+# `from dartbrains_tools.notebook_utils import youtube` lives in this
+# regular cell (not in the `with app.setup:` block above) so that when
+# this notebook runs in WASM mode, marimo-book's micropip bootstrap
+# cell can install `dartbrains-tools` from PyPI before this import
+# tries to resolve. The setup block runs at module import time and
+# can't be made to wait on async work; a regular `@app.cell` waits on
+# the bootstrap via marimo's dataflow scheduler. Cells that use
+# `youtube` take it as a parameter (see `sine_vid`, `tf_video`,
+# `dft_vid`, `fft_details`).
+@app.cell(hide_code=True)
+def _():
+    from dartbrains_tools.notebook_utils import youtube
+    return (youtube,)
 
 
 @app.cell(hide_code=True)
@@ -332,7 +345,7 @@ def osc_intro():
 
 
 @app.cell(hide_code=True)
-def sine_vid():
+def sine_vid(youtube):
     youtube("9RvZXZ46FRQ")
     return
 
@@ -508,7 +521,7 @@ def tf_intro():
 
 
 @app.cell(hide_code=True)
-def tf_video():
+def tf_video(youtube):
     youtube("fYtVHhk3xJ0")
     return
 
@@ -533,7 +546,7 @@ def freq_intro():
 
 
 @app.cell(hide_code=True)
-def dft_vid():
+def dft_vid(youtube):
     youtube("_htCsieA0_U")
     return
 
@@ -725,7 +738,7 @@ def dft_compute(
 
 
 @app.cell(hide_code=True)
-def fft_details():
+def fft_details(youtube):
     mo.vstack([mo.md("Let's learn a few more important details about the DFT:"), youtube("RHjqvcKVopg")])
     return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ build = [
 
 [dependency-groups]
 build = [
-    "marimo-book>=0.1.5",
+    "marimo-book>=0.1.8",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -568,7 +568,7 @@ requires-dist = [
 provides-extras = ["build"]
 
 [package.metadata.requires-dev]
-build = [{ name = "marimo-book", specifier = ">=0.1.5" }]
+build = [{ name = "marimo-book", specifier = ">=0.1.8" }]
 
 [[package]]
 name = "dartbrains-tools"
@@ -1467,7 +1467,7 @@ wheels = [
 
 [[package]]
 name = "marimo-book"
-version = "0.1.5"
+version = "0.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1485,9 +1485,9 @@ dependencies = [
     { name = "typer" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/71/2eaad7b110bb6d2f8a058a94665a29641f2b31aa613dea61d8bc8734b757/marimo_book-0.1.5.tar.gz", hash = "sha256:074de9978e9d7d5d819c3e12b29a2b0bdf260c9be666e1d6d6b19c0e686dfab1", size = 159884, upload-time = "2026-04-27T23:36:11.025Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/e3/2ccab1e60a3b229e51ce14272ee646944d6d3eaeb53fe571505cd8aa460f/marimo_book-0.1.8.tar.gz", hash = "sha256:b8e85b08f9930f4a8ba401a458365a2fbcdbe3c790bcaa0d822229a17d9e9d42", size = 160807, upload-time = "2026-04-28T00:13:57.996Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/f9/aa013b2488176a2662b07e540b90471dcabd2f22ce8188d8b3b5910b56a7/marimo_book-0.1.5-py3-none-any.whl", hash = "sha256:858cf692651a2ef446310d23bc1bcdea50e539fcdfcd0a25375032217a83f552", size = 80164, upload-time = "2026-04-27T23:36:09.324Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e2/512be79bf10be1fbcb814afb3c57dece60285c2172d61db5cd1c88ddd840/marimo_book-0.1.8-py3-none-any.whl", hash = "sha256:e8692f4689170d78feb601f9bb6759438f255395e11c33ab6d28259406645cc0", size = 80560, upload-time = "2026-04-28T00:13:56.697Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

WASM-mode pages need micropip to install non-Pyodide-bundled deps. \`dartbrains-tools\` is pure-Python on PyPI but not in Pyodide's bundle, so it has to be installed via micropip at runtime. marimo-book's WASM build now auto-injects an \`await micropip.install([...])\` bootstrap cell into every notebook with WASM mode, but \`with app.setup:\` blocks run at module-import time before any \`@app.cell\`, and \`await\` is invalid at module level — so the install can't happen inside setup.

## What changed

- \`content/Signal_Processing.py\`:
  - Removed \`from dartbrains_tools.notebook_utils import youtube\` from the \`with app.setup:\` block.
  - Added a new \`@app.cell(hide_code=True) def _():\` that does the import and returns \`youtube\`.
  - Added \`youtube\` parameter to the four cells that use it (\`sine_vid\`, \`tf_video\`, \`dft_vid\`, \`fft_details\`).

The other setup-block imports (numpy, matplotlib, scipy, scipy.signal, etc.) stay where they are — Pyodide's \`loadPackagesFromImports\` auto-loads those bundled packages without needing micropip.

## Test plan

- [x] \`marimo-book build -b book.yml --rebuild\` clean: Signal_Processing page renders with 0 cell errors and bootstrap cell injected
- [ ] Browser validation against the deployed site (after marimo-book release lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)