### PR TITLE
Bump marimo-book 0.1.8 → 0.1.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ build = [
 
 [dependency-groups]
 build = [
-    "marimo-book>=0.1.8",
+    "marimo-book>=0.1.9",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -568,7 +568,7 @@ requires-dist = [
 provides-extras = ["build"]
 
 [package.metadata.requires-dev]
-build = [{ name = "marimo-book", specifier = ">=0.1.8" }]
+build = [{ name = "marimo-book", specifier = ">=0.1.9" }]
 
 [[package]]
 name = "dartbrains-tools"
@@ -1467,7 +1467,7 @@ wheels = [
 
 [[package]]
 name = "marimo-book"
-version = "0.1.8"
+version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1485,9 +1485,9 @@ dependencies = [
     { name = "typer" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/e3/2ccab1e60a3b229e51ce14272ee646944d6d3eaeb53fe571505cd8aa460f/marimo_book-0.1.8.tar.gz", hash = "sha256:b8e85b08f9930f4a8ba401a458365a2fbcdbe3c790bcaa0d822229a17d9e9d42", size = 160807, upload-time = "2026-04-28T00:13:57.996Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f7/bbd960443745c4867d15390d705ccbce51cb2937818c1c81f512501f2ba5/marimo_book-0.1.9.tar.gz", hash = "sha256:71a9f2c77d61694c6744bdc3c5dc09a360d50957c2edaa7aa9f15c5ae2494309", size = 181583, upload-time = "2026-04-28T11:47:49.169Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/e2/512be79bf10be1fbcb814afb3c57dece60285c2172d61db5cd1c88ddd840/marimo_book-0.1.8-py3-none-any.whl", hash = "sha256:e8692f4689170d78feb601f9bb6759438f255395e11c33ab6d28259406645cc0", size = 80560, upload-time = "2026-04-28T00:13:56.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ca/9840eb0150201f97d82728e621d63cb5f41c461b7187e104a91cad4131d7/marimo_book-0.1.9-py3-none-any.whl", hash = "sha256:eb85787b593a3962b72db6d8b4c0b2de02977c5f1ae96b2702e95417a6dae5fc", size = 92387, upload-time = "2026-04-28T11:47:47.458Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Picks up the WASM micropip-bootstrap injection that auto-installs third-party PyPI deps (\`dartbrains-tools\`, \`nltools\`, etc.) inside the in-browser Pyodide kernel before any cell runs. Combined with the Signal_Processing.py setup-block refactor in #67, this should unblock all three WASM-mode chapters: MR_Physics, Preprocessing, Signal_Processing.

## marimo-book 0.1.9 highlights

- **WASM auto-installs third-party deps** via in-browser micropip (#38, #40, #41 in marimo-book)
- **\`marimo-book sync-deps\`** new CLI for committing generated PEP 723 blocks to source notebooks
- **\`dependencies.{auto_pep723, pin, extras, overrides, requires_python}\`** new \`book.yml\` knobs
- **WASM init "Initializing…" spinner removed** (was lingering above already-working reactive cells)
- **Sidebar logo centered** when \`logo_placement: sidebar\`
- **Per-notebook \*Written by …\* attributions** no longer stripped

Full changelog: https://github.com/ljchang/marimo-book/releases/tag/v0.1.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)