### PR TITLE
Opt into suppress_warnings to fix ICA precompute slider placement

### DIFF
--- a/book.yml
+++ b/book.yml
@@ -29,6 +29,18 @@ launch_buttons:
   github: true
   download: true
 
+# Run `marimo export` with PYTHONWARNINGS=ignore so library warnings
+# (numpy / nltools / pandas deprecation notices, etc.) don't surface
+# as visible stderr blocks in cell output. Also keeps the precompute
+# slider's inline mount stable: when warning text differs across the
+# per-value re-exports, the diff detector flags upstream cells (data
+# load, filter+smooth) as "reactive" and the slider mounts inline
+# with the wrong cell — the brain viewer ends up far below the
+# slider. Suppressing warnings makes those cell outputs deterministic
+# so only the actual viewer cell is flagged.
+defaults:
+  suppress_warnings: true
+
 # Google Analytics — GA4 Measurement ID for dartbrains.org.
 # (The legacy UA-138270939-1 Universal Analytics property was retired
 # by Google on 2023-07-01; this is its GA4 successor.)


### PR DESCRIPTION
The precompute pipeline re-exports each marimo notebook once per slider value and diffs cell outputs to mark which cells are \"reactive\" (downstream of the slider). It mounts the slider inline above the first reactive cell.

Library warnings (numpy / nltools / pandas / sklearn deprecations, etc.) often embed timestamps, paths, or other non-deterministic text in their stderr. Across two re-exports the warning text differs, the diff detector flags upstream cells (data load, filter+smooth) as reactive, and the slider mounts inline with one of those — so the brain viewer ends up far below the slider on the rendered page.

\`defaults.suppress_warnings: true\` runs \`marimo export\` with \`PYTHONWARNINGS=ignore\`, making per-value re-exports deterministic. Only the genuinely reactive cell (the brain viewer) gets flagged, and the slider mounts where the reader expects it.

Carries the intent of the closed PR #59 (which targeted an older marimo-book pin against a now-merged branch) under the current master + marimo-book 0.1.9 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)