### PR TITLE
Add Sherlock + Paranoia datasets; migrate notebooks to localizer namespace

### DIFF
--- a/content/Connectivity.py
+++ b/content/Connectivity.py
@@ -105,14 +105,14 @@ def _():
     import networkx as nx
     from nilearn.plotting import plot_stat_map, view_img_on_surf
     import nibabel as nib
-    from dartbrains_tools.data import get_file, get_tr, load_events, load_confounds, get_subjects
+    from dartbrains_tools.data import localizer
     from dartbrains_tools.notebook_utils import youtube
 
 
     def get_csf_mask_path(subject):
         """Per-subject CSF probability mask from fmriprep outputs."""
         from pathlib import Path as _Path
-        bold_path = _Path(get_file(subject, 'derivatives', 'bold'))
+        bold_path = _Path(localizer.get_file(subject, 'derivatives', 'bold'))
         return str(bold_path.parent.parent / 'anat' /
                    f'sub-{subject}_space-MNI152NLin2009cAsym_label-CSF_probseg.nii.gz')
 
@@ -124,11 +124,8 @@ def _():
         fft,
         fftfreq,
         get_csf_mask_path,
-        get_file,
-        get_tr,
         go,
-        load_confounds,
-        load_events,
+        localizer,
         make_subplots,
         nib,
         np,
@@ -152,10 +149,10 @@ def _(mo):
 
 
 @app.cell
-def _(Brain_Data, get_file, mo):
+def _(Brain_Data, localizer, mo):
     sub = 'S01'
     _fwhm = 6
-    data = Brain_Data(get_file(sub, 'derivatives', 'bold'))
+    data = Brain_Data(localizer.get_file(sub, 'derivatives', 'bold'))
 
     with mo.persistent_cache(name="connectivity_smoothed"):
         smoothed = data.smooth(fwhm=_fwhm)
@@ -250,15 +247,14 @@ def _(
     Design_Matrix,
     data,
     get_csf_mask_path,
-    get_tr,
-    load_confounds,
+    localizer,
     pd,
     smoothed,
     sub,
     vmpfc,
     zscore,
 ):
-    tr = get_tr()
+    tr = localizer.get_tr()
     _fwhm = 6
     n_tr = len(data)
 
@@ -283,7 +279,7 @@ def _(
     _csf_mask = Brain_Data(get_csf_mask_path(sub)).threshold(upper=0.7, binarize=True)
     csf = zscore(pd.DataFrame(smoothed.extract_roi(mask=_csf_mask).T, columns=['csf']))
     spikes = smoothed.find_spikes(global_spike_cutoff=3, diff_spike_cutoff=3)
-    _covariates = load_confounds(sub)
+    _covariates = localizer.load_confounds(sub)
     _mc = _covariates[['trans_x', 'trans_y', 'trans_z', 'rot_x', 'rot_y', 'rot_z']]
     mc_cov = make_motion_covariates(_mc, tr)
     dm = Design_Matrix(pd.concat([vmpfc_1, csf, mc_cov, spikes.drop(labels='TR', axis=1)], axis=1), sampling_freq=1 / tr)
@@ -325,8 +321,8 @@ def _(mo):
 
 
 @app.cell
-def _(get_file, nib):
-    _img = nib.load(get_file('S01', 'derivatives', 'bold'))
+def _(localizer, nib):
+    _img = nib.load(localizer.get_file('S01', 'derivatives', 'bold'))
     print(f'shape: {_img.shape}')
     print(f'voxel size: {_img.header.get_zooms()}')
     print(f'TR: {_img.header.get_zooms()[3]} s')
@@ -338,9 +334,7 @@ def _(get_file, nib):
 def _(
     Design_Matrix,
     csf,
-    get_file,
-    get_tr,
-    load_events,
+    localizer,
     mc_cov,
     nib,
     np,
@@ -359,9 +353,9 @@ def _(
         horizontally concatenated with other 0..n_tr-indexed DataFrames.
         """
         from nilearn.glm.first_level import make_first_level_design_matrix as _make_dm
-        tr = get_tr()
-        n_tr = nib.load(get_file(subject, 'derivatives', 'bold')).shape[-1]
-        onsets = load_events(subject)
+        tr = localizer.get_tr()
+        n_tr = nib.load(localizer.get_file(subject, 'derivatives', 'bold')).shape[-1]
+        onsets = localizer.load_events(subject)
         frame_times = np.arange(n_tr) * tr
         dm_raw = _make_dm(frame_times, events=onsets, hrf_model='glover', drift_model=None)
         convolved = [c for c in dm_raw.columns if c != 'constant']
@@ -549,7 +543,7 @@ def _(
     Brain_Data,
     Design_Matrix,
     get_csf_mask_path,
-    load_confounds,
+    localizer,
     make_motion_covariates,
     pd,
     smoothed,
@@ -561,7 +555,7 @@ def _(
     _csf_mask = Brain_Data(get_csf_mask_path(sub)).threshold(upper=0.7, binarize=True)
     csf_1 = zscore(pd.DataFrame(smoothed.extract_roi(mask=_csf_mask).T, columns=['csf']))
     spikes_1 = smoothed.find_spikes(global_spike_cutoff=3, diff_spike_cutoff=3)
-    _covariates = load_confounds(sub)
+    _covariates = localizer.load_confounds(sub)
     _mc = _covariates[['trans_x', 'trans_y', 'trans_z', 'rot_x', 'rot_y', 'rot_z']]
     mc_cov_1 = make_motion_covariates(_mc, tr)
     dm_2 = Design_Matrix(pd.concat([vmpfc_1, csf_1, mc_cov_1, spikes_1.drop(labels='TR', axis=1)], axis=1), sampling_freq=1 / tr)
@@ -617,8 +611,8 @@ def _(
     component_slider,
     fft,
     fftfreq,
-    get_tr,
     go,
+    localizer,
     make_subplots,
     mo,
     np,
@@ -645,12 +639,12 @@ def _(
     # Timecourse + power spectrum (plotly subplots)
     _weights = pca_stats_output['weights'][:, _comp]
     _y = fft(_weights)
-    _freqs = fftfreq(len(_y), d=get_tr())
+    _freqs = fftfreq(len(_y), d=localizer.get_tr())
     _pos_mask = _freqs > 0
 
     _fig = make_subplots(
         rows=2, cols=1, vertical_spacing=0.18,
-        subplot_titles=(f'Timecourse (TR={get_tr()}s)', 'Power Spectrum'),
+        subplot_titles=(f'Timecourse (TR={localizer.get_tr()}s)', 'Power Spectrum'),
     )
     _fig.add_trace(go.Scatter(
         y=_weights, mode='lines', line=dict(color='red', width=2),

--- a/content/Download_Data.py
+++ b/content/Download_Data.py
@@ -722,6 +722,75 @@ def _(mo):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
+    ## Sherlock Dataset
+
+    The [Sherlock dataset](https://huggingface.co/datasets/dartbrains/sherlock)
+    (Chen et al., 2017) contains 16 subjects who watched ~50 minutes of
+    *Sherlock* across two scanning runs and then verbally recalled the
+    narrative in the scanner. TR = 1.5 s. We use this dataset in the
+    naturalistic-data tutorials (intersubject correlation, event
+    segmentation, functional alignment).
+
+    Access via `dartbrains_tools.data.sherlock`:
+    """)
+    return
+
+
+@app.cell
+def _():
+    from dartbrains_tools.data import sherlock
+
+    print(f"Subjects: {sherlock.get_subjects()[:3]} ... ({len(sherlock.get_subjects())} total)")
+    print(f"Tasks: {sherlock.get_tasks()}")
+    print(f"TR: {sherlock.get_tr()} s")
+
+    # Per-subject preprocessed bold (lazy download, ~800 MB each)
+    bold_path = sherlock.get_file("sub-01", task="sherlockPart1", suffix="bold")
+    print(f"\nBOLD path: {bold_path}")
+
+    # Confounds + scene onsets are small
+    confounds = sherlock.load_confounds("sub-01", task="sherlockPart1")
+    watch_onsets = sherlock.load_onsets("watch")
+    print(f"\nConfounds: {confounds.shape}; Watch onsets: {watch_onsets.shape}")
+    return (sherlock,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## Paranoia Dataset
+
+    The [Paranoia dataset](https://huggingface.co/datasets/dartbrains/paranoia)
+    (Finn et al., 2018) contains 22 subjects who listened to a three-part
+    ambiguous social narrative (~22 minutes total). TR = 1.0 s. Each subject
+    completed 3 story runs.
+
+    Access via `dartbrains_tools.data.paranoia`:
+    """)
+    return
+
+
+@app.cell
+def _():
+    from dartbrains_tools.data import paranoia
+
+    print(f"Subjects: {paranoia.get_subjects()[:3]} ... ({len(paranoia.get_subjects())} total)")
+    print(f"Runs: {paranoia.get_runs()}")
+    print(f"TR: {paranoia.get_tr()} s")
+
+    # Demographics + trait paranoia score
+    participants = paranoia.load_participants()
+    print(f"\nParticipants:\n{participants.head()}")
+
+    # Story 1 transcript (small)
+    transcript = paranoia.load_transcript(1)
+    print(f"\nStory 1 transcript (first 200 chars):\n{transcript[:200]}")
+    return (paranoia,)
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
     (run-preprocessing)=
     ## Preprocessing
     The data has already been preprocessed using [fmriprep](https://fmriprep.readthedocs.io/en/stable/), which is a robust, but opinionated automated preprocessing pipeline developed by [Russ Poldrack's group at Stanford University](https://poldracklab.stanford.edu/). The developer's have made a number of choices about how to preprocess your fMRI data using best practices and have created an automated pipeline using multiple software packages that are all distributed via a [docker container](https://fmriprep.org/en/1.5.9/docker.html).

--- a/content/Download_Data.py
+++ b/content/Download_Data.py
@@ -73,16 +73,16 @@ def _(mo):
 
 @app.cell
 def _():
-    from dartbrains_tools.data import get_file, get_subjects, load_events, get_tr, REPO_ID
+    from dartbrains_tools.data import localizer
 
     # List all subjects
-    print(f"Subjects: {get_subjects()}")
-    print(f"TR: {get_tr()} seconds")
+    print(f"Subjects: {localizer.get_subjects()}")
+    print(f"TR: {localizer.get_tr()} seconds")
 
     # Download a preprocessed BOLD file (cached after first download)
-    bold_path = get_file('S01', 'derivatives', 'bold')
+    bold_path = localizer.get_file('S01', 'derivatives', 'bold')
     print(f"\nBOLD file path: {bold_path}")
-    return REPO_ID, load_events
+    return (localizer,)
 
 
 @app.cell(hide_code=True)
@@ -96,8 +96,8 @@ def _(mo):
 
 
 @app.cell
-def _(load_events):
-    events = load_events('S01')
+def _(localizer):
+    events = localizer.load_events('S01')
     events.head(10)
     return
 
@@ -113,12 +113,12 @@ def _(mo):
 
 
 @app.cell
-def _(REPO_ID):
+def _(localizer):
     from huggingface_hub import hf_hub_download
 
     # Download a specific beta map
     path = hf_hub_download(
-        repo_id=REPO_ID,
+        repo_id=localizer.REPO_ID,
         filename="derivatives/betas/S01_betas.nii.gz",
         repo_type="dataset",
     )
@@ -132,11 +132,11 @@ def _(mo):
         mo.md(r"""
         ### Browsing the Dataset as a BIDS Tree
 
-        `hf_hub_download` and `get_file()` cache files in `~/.cache/huggingface/hub/datasets--dartbrains--localizer/`, but the cache uses a content-addressed layout (`blobs/` for raw bytes, `snapshots/<commit>/` for symlinks back to those blobs with their original filenames). The `snapshots/` folder *does* preserve the original BIDS tree exactly, but the path is awkward to access.
+        `hf_hub_download` and `localizer.get_file()` cache files in `~/.cache/huggingface/hub/datasets--dartbrains--localizer/`, but the cache uses a content-addressed layout (`blobs/` for raw bytes, `snapshots/<commit>/` for symlinks back to those blobs with their original filenames). The `snapshots/` folder *does* preserve the original BIDS tree exactly, but the path is awkward to access.
 
         If you'd rather browse the dataset like a normal BIDS directory — `cd` into it, `ls` subjects, drag it into a file explorer, point external tools at it — the cleanest pattern is to download a full snapshot and symlink it to a friendly location of your choice.
 
-         First, pull the snapshot. Files you've already cached with `get_file()` or `hf_hub_download` are reused, so this is fast on a second call:
+         First, pull the snapshot. Files you've already cached with `localizer.get_file()` or `hf_hub_download` are reused, so this is fast on a second call:
         """),
         mo.callout(
             mo.md(
@@ -158,11 +158,11 @@ def _(mo):
 
 
 @app.cell
-def _(REPO_ID):
+def _(localizer):
     from huggingface_hub import snapshot_download
 
     snapshot_path = snapshot_download(
-        repo_id=REPO_ID,
+        repo_id=localizer.REPO_ID,
         repo_type="dataset",
     )
     print(f"Snapshot lives at:\n  {snapshot_path}")
@@ -752,7 +752,7 @@ def _():
     confounds = sherlock.load_confounds("sub-01", task="sherlockPart1")
     watch_onsets = sherlock.load_onsets("watch")
     print(f"\nConfounds: {confounds.shape}; Watch onsets: {watch_onsets.shape}")
-    return (sherlock,)
+    return
 
 
 @app.cell(hide_code=True)
@@ -785,7 +785,7 @@ def _():
     # Story 1 transcript (small)
     transcript = paranoia.load_transcript(1)
     print(f"\nStory 1 transcript (first 200 chars):\n{transcript[:200]}")
-    return (paranoia,)
+    return
 
 
 @app.cell(hide_code=True)

--- a/content/Download_Data.py
+++ b/content/Download_Data.py
@@ -745,13 +745,13 @@ def _():
     print(f"TR: {sherlock.get_tr()} s")
 
     # Per-subject preprocessed bold (lazy download, ~800 MB each)
-    bold_path = sherlock.get_file("sub-01", task="sherlockPart1", suffix="bold")
-    print(f"\nBOLD path: {bold_path}")
+    _bold_path = sherlock.get_file("sub-01", task="sherlockPart1", suffix="bold")
+    print(f"\nBOLD path: {_bold_path}")
 
     # Confounds + scene onsets are small
-    confounds = sherlock.load_confounds("sub-01", task="sherlockPart1")
-    watch_onsets = sherlock.load_onsets("watch")
-    print(f"\nConfounds: {confounds.shape}; Watch onsets: {watch_onsets.shape}")
+    _confounds = sherlock.load_confounds("sub-01", task="sherlockPart1")
+    _watch_onsets = sherlock.load_onsets("watch")
+    print(f"\nConfounds: {_confounds.shape}; Watch onsets: {_watch_onsets.shape}")
     return
 
 
@@ -779,12 +779,12 @@ def _():
     print(f"TR: {paranoia.get_tr()} s")
 
     # Demographics + trait paranoia score
-    participants = paranoia.load_participants()
-    print(f"\nParticipants:\n{participants.head()}")
+    _participants = paranoia.load_participants()
+    print(f"\nParticipants:\n{_participants.head()}")
 
     # Story 1 transcript (small)
-    transcript = paranoia.load_transcript(1)
-    print(f"\nStory 1 transcript (first 200 chars):\n{transcript[:200]}")
+    _transcript = paranoia.load_transcript(1)
+    print(f"\nStory 1 transcript (first 200 chars):\n{_transcript[:200]}")
     return
 
 

--- a/content/GLM_Single_Subject_Model.py
+++ b/content/GLM_Single_Subject_Model.py
@@ -74,16 +74,14 @@ def _():
     from nltools.data import Brain_Data, Design_Matrix
     from nltools.stats import find_spikes
     from nilearn.plotting import view_img, glass_brain, plot_stat_map
-    from dartbrains_tools.data import get_file, get_tr, load_events, get_subjects
+    from dartbrains_tools.data import localizer
     from dartbrains_tools.notebook_utils import youtube
 
 
     return (
         Brain_Data,
         Design_Matrix,
-        get_file,
-        get_tr,
-        load_events,
+        localizer,
         nib,
         np,
         onsets_to_dm,
@@ -104,14 +102,14 @@ def _(mo):
 
 
 @app.cell
-def _(get_file, get_tr, load_events, nib, onsets_to_dm):
+def _(localizer, nib, onsets_to_dm):
     def load_bids_events(subject):
         '''Create a design_matrix instance from BIDS event file'''
 
-        tr = get_tr()
-        n_tr = nib.load(get_file(subject, 'derivatives', 'bold')).shape[-1]
+        tr = localizer.get_tr()
+        n_tr = nib.load(localizer.get_file(subject, 'derivatives', 'bold')).shape[-1]
 
-        onsets = load_events(subject)
+        onsets = localizer.load_events(subject)
         dm = onsets_to_dm(onsets, run_length=n_tr, TR=tr, hrf_model=None)
         # nilearn auto-adds a 'constant' intercept; drop it so .add_poly() later
         # is the single source of the intercept (avoids a rank-deficient design).
@@ -395,9 +393,9 @@ def _(mo):
 
 
 @app.cell
-def _(Brain_Data, get_file):
+def _(Brain_Data, localizer):
     sub = 'S01'
-    data = Brain_Data(get_file(sub, 'derivatives', 'bold'))
+    data = Brain_Data(localizer.get_file(sub, 'derivatives', 'bold'))
     return data, sub
 
 
@@ -410,8 +408,8 @@ def _(mo):
 
 
 @app.cell
-def _(get_file, pd, plt, zscore):
-    covariates = pd.read_csv(get_file('S01', 'derivatives', 'confounds'), sep='\t')
+def _(localizer, pd, plt, zscore):
+    covariates = pd.read_csv(localizer.get_file('S01', 'derivatives', 'confounds'), sep='\t')
 
     mc = covariates[['trans_x','trans_y','trans_z','rot_x', 'rot_y', 'rot_z']]
 
@@ -431,7 +429,7 @@ def _(mo):
 
 
 @app.cell
-def _(Design_Matrix, get_tr, mc, pd, sns, zscore):
+def _(Design_Matrix, localizer, mc, pd, sns, zscore):
     def make_motion_covariates(mc, tr):
         z_mc = zscore(mc)
         z_mc_sq = z_mc ** 2
@@ -444,7 +442,7 @@ def _(Design_Matrix, get_tr, mc, pd, sns, zscore):
         all_mc.fillna(value=0, inplace=True)
         return Design_Matrix(all_mc, sampling_freq=1/tr)
 
-    tr = get_tr()
+    tr = localizer.get_tr()
     mc_cov = make_motion_covariates(mc, tr)
 
     sns.heatmap(mc_cov)

--- a/content/Group_Analysis.py
+++ b/content/Group_Analysis.py
@@ -138,7 +138,7 @@ def _():
     from nltools.stats import regress
     from nltools.external import glover_hrf
     from scipy.stats import ttest_1samp
-    from dartbrains_tools.data import get_file, get_subjects, get_tr, load_events, load_confounds, CONDITIONS
+    from dartbrains_tools.data import localizer
     from dartbrains_tools.notebook_utils import plot_timeseries
 
     def simulate_timeseries(n_tr=200, n_trial=5, amplitude=1, tr=1, sigma=0.05):
@@ -152,8 +152,7 @@ def _():
 
     return (
         Brain_Data,
-        get_file,
-        get_subjects,
+        localizer,
         np,
         pd,
         plot_timeseries,
@@ -340,19 +339,19 @@ def _(mo):
     from nltools.data import Brain_Data, Design_Matrix
     from nltools.file_reader import onsets_to_dm
     from nilearn.plotting import view_img, glass_brain, plot_stat_map
-    from dartbrains_tools.data import get_file, get_subjects, get_tr, load_events, load_confounds, CONDITIONS
+    from dartbrains_tools.data import localizer
 
-    tr = get_tr()
+    tr = localizer.get_tr()
     fwhm = 6
     spike_cutoff = 3
 
     def load_bids_events(subject):
         '''Create a design_matrix instance from BIDS event file'''
 
-        tr = get_tr()
-        n_tr = nib.load(get_file(subject, 'derivatives', 'bold')).shape[-1]
+        tr = localizer.get_tr()
+        n_tr = nib.load(localizer.get_file(subject, 'derivatives', 'bold')).shape[-1]
 
-        onsets = load_events(subject)
+        onsets = localizer.load_events(subject)
         onsets.columns = ['Onset', 'Duration', 'Stim']
         return onsets_to_dm(onsets, sampling_freq=1/tr, run_length=n_tr)
 
@@ -362,11 +361,11 @@ def _(mo):
         all_mc.fillna(value=0, inplace=True)
         return Design_Matrix(all_mc, sampling_freq=1/tr)
 
-    for sub in tqdm(get_subjects()):
-        data = Brain_Data(get_file(sub, 'derivatives', 'bold'))
+    for sub in tqdm(localizer.get_subjects()):
+        data = Brain_Data(localizer.get_file(sub, 'derivatives', 'bold'))
         data = data.smooth(fwhm=fwhm)
         dm = load_bids_events(sub)
-        covariates = load_confounds(sub)
+        covariates = localizer.load_confounds(sub)
         mc_cov = make_motion_covariates(covariates[['trans_x','trans_y','trans_z','rot_x', 'rot_y', 'rot_z']])
         spikes = data.find_spikes(global_spike_cutoff=spike_cutoff, diff_spike_cutoff=spike_cutoff)
         dm_cov = dm.convolve().add_dct_basis(duration=128).add_poly(order=1, include_lower=True)
@@ -402,9 +401,9 @@ def _(mo):
 
 
 @app.cell
-def _(Brain_Data, get_file, get_subjects):
+def _(Brain_Data, localizer):
     con1_name = 'horizontal_checkerboard'
-    con1_dat = Brain_Data([Brain_Data(get_file(sub, 'betas', con1_name)) for sub in get_subjects()])
+    con1_dat = Brain_Data([Brain_Data(localizer.get_file(sub, 'betas', con1_name)) for sub in localizer.get_subjects()])
     return (con1_dat,)
 
 
@@ -465,9 +464,9 @@ def _(mo):
 
 
 @app.cell
-def _(Brain_Data, con1_dat, get_file, get_subjects):
+def _(Brain_Data, con1_dat, localizer):
     con2_name = 'vertical_checkerboard'
-    con2_dat = Brain_Data([Brain_Data(get_file(sub, 'betas', con2_name)) for sub in get_subjects()])
+    con2_dat = Brain_Data([Brain_Data(localizer.get_file(sub, 'betas', con2_name)) for sub in localizer.get_subjects()])
 
     con1_v_con2 = con1_dat-con2_dat
     return (con1_v_con2,)

--- a/content/ICA.py
+++ b/content/ICA.py
@@ -63,25 +63,15 @@ def _():
     from plotly.subplots import make_subplots
     from nltools.data import Brain_Data
     from nilearn.plotting import view_img
-    from dartbrains_tools.data import get_file, get_tr
+    from dartbrains_tools.data import localizer
 
-    return (
-        Brain_Data,
-        fft,
-        fftfreq,
-        get_file,
-        get_tr,
-        go,
-        make_subplots,
-        np,
-        view_img,
-    )
+    return Brain_Data, fft, fftfreq, go, localizer, make_subplots, np, view_img
 
 
 @app.cell
-def _(Brain_Data, get_file):
+def _(Brain_Data, localizer):
     sub = 'S01'
-    data = Brain_Data(get_file(sub, 'derivatives', 'bold'))
+    data = Brain_Data(localizer.get_file(sub, 'derivatives', 'bold'))
     return (data,)
 
 
@@ -97,8 +87,8 @@ def _(mo):
 
 
 @app.cell
-def _(data, get_tr, mo):
-    tr = get_tr()
+def _(data, localizer, mo):
+    tr = localizer.get_tr()
     with mo.persistent_cache("ica_preprocess"):
         data_1 = data.filter(sampling_freq=1 / tr, high_pass=1 / 128)
         data_1 = data_1.smooth(6)

--- a/content/Introduction_to_Neuroimaging_Data.py
+++ b/content/Introduction_to_Neuroimaging_Data.py
@@ -9,7 +9,7 @@ def _():
     import marimo as mo
     from pathlib import Path
     import os
-    from dartbrains_tools.data import get_file, get_subjects, get_tr, load_events, load_confounds, REPO_ID, CONDITIONS
+    from dartbrains_tools.data import localizer
     from huggingface_hub import hf_hub_download
     import nibabel as nib
     import matplotlib.pyplot as plt
@@ -21,9 +21,7 @@ def _():
     return (
         Brain_Data,
         get_anatomical,
-        get_file,
-        get_subjects,
-        load_events,
+        localizer,
         mo,
         nib,
         plot_anat,
@@ -187,16 +185,16 @@ def _(mo):
     The Localizer dataset is hosted on [HuggingFace](https://huggingface.co/datasets/dartbrains/localizer) in BIDS format. We provide helper functions in `dartbrains_tools.data` that download files on demand and cache them locally:
 
     ```python
-    from dartbrains_tools.data import get_file, get_subjects, load_events
+    from dartbrains_tools.data import localizer
 
     # Get the preprocessed BOLD file for subject S01
-    bold_path = get_file('S01', 'derivatives', 'bold')
+    bold_path = localizer.get_file('S01', 'derivatives', 'bold')
 
     # Get a list of all subjects
-    subjects = get_subjects()  # ['S01', 'S02', ..., 'S20']
+    subjects = localizer.get_subjects()  # ['S01', 'S02', ..., 'S20']
 
     # Load event timing for a subject
-    events = load_events('S01')
+    events = localizer.load_events('S01')
     ```
 
     Files are downloaded from HuggingFace Hub the first time you request them and cached locally for subsequent use.
@@ -213,8 +211,8 @@ def _(mo):
 
 
 @app.cell
-def _(get_subjects):
-    subjects = get_subjects()
+def _(localizer):
+    subjects = localizer.get_subjects()
     subjects[:10]
     return
 
@@ -222,14 +220,14 @@ def _(get_subjects):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    We can also retrieve the path to a specific file. For example, let's get the preprocessed BOLD file for the first 10 subjects. The `get_file` function downloads the file from HuggingFace Hub on first access and returns the local cached path.
+    We can also retrieve the path to a specific file. For example, let's get the preprocessed BOLD file for the first 10 subjects. The `localizer.get_file` function downloads the file from HuggingFace Hub on first access and returns the local cached path.
     """)
     return
 
 
 @app.cell
-def _(get_file, get_subjects):
-    bold_files = [get_file(sub, 'derivatives', 'bold') for sub in get_subjects()[:10]]
+def _(localizer):
+    bold_files = [localizer.get_file(sub, 'derivatives', 'bold') for sub in localizer.get_subjects()[:10]]
     bold_files
     return
 
@@ -256,8 +254,8 @@ def _(mo):
 
 
 @app.cell
-def _(get_file):
-    f = get_file('S01', 'derivatives', 'bold')
+def _(localizer):
+    f = localizer.get_file('S01', 'derivatives', 'bold')
     f
     return
 
@@ -273,8 +271,8 @@ def _(mo):
 
 
 @app.cell
-def _(load_events):
-    events_df = load_events('S01')
+def _(localizer):
+    events_df = localizer.load_events('S01')
     events_df.head(10)
     return
 
@@ -291,14 +289,14 @@ def _(mo):
 
     We will be loading an anatomical image from subject S01 from the localizer [dataset](Download_Data.md).  See this [paper](https://bmcneurosci.biomedcentral.com/articles/10.1186/1471-2202-8-91) for more information about this dataset.
 
-    We will use our `get_file` helper to grab subject S01's T1 image.
+    We will use our `localizer.get_file` helper to grab subject S01's T1 image.
     """)
     return
 
 
 @app.cell
-def _(get_file, nib):
-    data = nib.load(get_file('S01', 'derivatives', 'T1w'))
+def _(localizer, nib):
+    data = nib.load(localizer.get_file('S01', 'derivatives', 'T1w'))
     return (data,)
 
 
@@ -590,8 +588,8 @@ def _(mo):
 
 
 @app.cell
-def _(Brain_Data, get_file):
-    data_1 = Brain_Data(get_file('S01', 'derivatives', 'bold'))
+def _(Brain_Data, localizer):
+    data_1 = Brain_Data(localizer.get_file('S01', 'derivatives', 'bold'))
     return (data_1,)
 
 
@@ -921,7 +919,7 @@ def _(mo):
     ### Exercise 1
     A few subjects have already been preprocessed with fMRI prep.
 
-    Use `get_subjects()` to figure out which subjects are available in the dataset.
+    Use `localizer.get_subjects()` to figure out which subjects are available in the dataset.
     """)
     return
 

--- a/content/Multivariate_Prediction.py
+++ b/content/Multivariate_Prediction.py
@@ -129,18 +129,9 @@ def _():
     from nltools.data import Brain_Data
     from nltools.mask import expand_mask
     from nilearn.plotting import view_img_on_surf
-    from dartbrains_tools.data import get_subjects, get_file
+    from dartbrains_tools.data import localizer
 
-    return (
-        Brain_Data,
-        expand_mask,
-        get_file,
-        get_subjects,
-        np,
-        os,
-        pd,
-        view_img_on_surf,
-    )
+    return Brain_Data, expand_mask, localizer, np, os, pd, view_img_on_surf
 
 
 @app.cell(hide_code=True)
@@ -154,10 +145,10 @@ def _(mo):
 
 
 @app.cell
-def _(Brain_Data, get_file, get_subjects):
-    _sub_list = get_subjects()
-    left_file_list = [get_file(sub, 'betas', 'video_left_hand') for sub in _sub_list]
-    right_file_list = [get_file(sub, 'betas', 'video_right_hand') for sub in _sub_list]
+def _(Brain_Data, localizer):
+    _sub_list = localizer.get_subjects()
+    left_file_list = [localizer.get_file(sub, 'betas', 'video_left_hand') for sub in _sub_list]
+    right_file_list = [localizer.get_file(sub, 'betas', 'video_right_hand') for sub in _sub_list]
 
     # nltools 0.5.1 quirk: Brain_Data(list-of-paths) flattens to 1D
     # ((20*238955,) instead of (20, 238955)), which then makes

--- a/content/RSA.py
+++ b/content/RSA.py
@@ -129,17 +129,15 @@ def _():
     from nltools.stats import fdr, threshold, fisher_r_to_z, one_sample_permutation
     from sklearn.metrics import pairwise_distances
     from nilearn.plotting import plot_glass_brain, plot_stat_map, view_img_on_surf, view_img
-    from dartbrains_tools.data import get_subjects, get_file, CONDITIONS
+    from dartbrains_tools.data import localizer
 
     return (
         Adjacency,
         Brain_Data,
-        CONDITIONS,
         expand_mask,
         fdr,
         fisher_r_to_z,
-        get_file,
-        get_subjects,
+        localizer,
         np,
         one_sample_permutation,
         pd,
@@ -164,10 +162,10 @@ def _(mo):
 
 
 @app.cell
-def _(Brain_Data, CONDITIONS, get_file):
+def _(Brain_Data, localizer):
     _sub = 'S01'
-    _file_list = [get_file(_sub, 'betas', cond) for cond in CONDITIONS]
-    conditions = CONDITIONS
+    _file_list = [localizer.get_file(_sub, 'betas', cond) for cond in localizer.CONDITIONS]
+    conditions = localizer.CONDITIONS
     # nltools 0.5.1 quirk: Brain_Data(list-of-paths) flattens into 1D
     # (e.g. (10*238955,) instead of (10, 238955)), which breaks every
     # downstream apply_mask / distance call. Wrap each path in
@@ -387,13 +385,13 @@ def _(mo):
 
 
 @app.cell
-def _(Brain_Data, CONDITIONS, get_file, get_subjects, mask_x, motor, pd):
-    sub_list = get_subjects()
+def _(Brain_Data, localizer, mask_x, motor, pd):
+    sub_list = localizer.get_subjects()
     all_sub_similarity = {}
     all_sub_motor_rsa = {}
     for _sub in sub_list:
-        _file_list = [get_file(_sub, 'betas', cond) for cond in CONDITIONS]
-        conditions_1 = CONDITIONS
+        _file_list = [localizer.get_file(_sub, 'betas', cond) for cond in localizer.CONDITIONS]
+        conditions_1 = localizer.CONDITIONS
         # See note on the single-subject cell above — wrap each path in
         # Brain_Data() so the outer constructor stacks instead of flattening.
         beta_1 = Brain_Data([Brain_Data(f) for f in _file_list])

--- a/content/Thresholding_Group_Analyses.py
+++ b/content/Thresholding_Group_Analyses.py
@@ -95,9 +95,9 @@ def _():
     import plotly.graph_objects as go
     from nltools.data import Brain_Data
     from nltools.simulator import SimulateGrid
-    from dartbrains_tools.data import get_file, get_subjects
+    from dartbrains_tools.data import localizer
 
-    return Brain_Data, SimulateGrid, get_file, get_subjects, go, np, plt, sns
+    return Brain_Data, SimulateGrid, go, localizer, np, plt, sns
 
 
 @app.cell(hide_code=True)
@@ -533,9 +533,9 @@ def _(mo):
 
 
 @app.cell
-def _(Brain_Data, get_file, get_subjects):
+def _(Brain_Data, localizer):
     con1_name = 'horizontal_checkerboard'
-    con1_file_list = [get_file(sub, 'betas', con1_name) for sub in get_subjects()]
+    con1_file_list = [localizer.get_file(sub, 'betas', con1_name) for sub in localizer.get_subjects()]
     con1_dat = Brain_Data([Brain_Data(f) for f in con1_file_list])
     _con1_stats = con1_dat.ttest(threshold_dict={'unc': 0.001})
     _con1_stats['thr_t'].iplot()
@@ -578,9 +578,9 @@ def _(mo):
 
 
 @app.cell
-def _(Brain_Data, con1_dat, get_file, get_subjects):
+def _(Brain_Data, con1_dat, localizer):
     con2_name = 'vertical_checkerboard'
-    con2_file_list = [get_file(sub, 'betas', con2_name) for sub in get_subjects()]
+    con2_file_list = [localizer.get_file(sub, 'betas', con2_name) for sub in localizer.get_subjects()]
     con2_dat = Brain_Data([Brain_Data(f) for f in con2_file_list])
     con1_v_con2 = con1_dat - con2_dat
     _con1_v_con2_stats = con1_v_con2.ttest(threshold_dict={'unc': 0.001})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 dependencies = [
     "anywidget>=0.9.21",
-    "dartbrains-tools>=0.1.2",
+    "dartbrains-tools>=0.1.4",
     "datalad>=1.3.4",
     "datasets>=4.8.4",
     "huggingface-hub[cli,hf-xet]>=1.8.0",

--- a/uv.lock
+++ b/uv.lock
@@ -544,7 +544,7 @@ build = [
 [package.metadata]
 requires-dist = [
     { name = "anywidget", specifier = ">=0.9.21" },
-    { name = "dartbrains-tools", specifier = ">=0.1.2" },
+    { name = "dartbrains-tools", specifier = ">=0.1.4" },
     { name = "datalad", specifier = ">=1.3.4" },
     { name = "datasets", specifier = ">=4.8.4" },
     { name = "huggingface-hub", extras = ["cli", "hf-xet"], specifier = ">=1.8.0" },
@@ -572,7 +572,7 @@ build = [{ name = "marimo-book", specifier = ">=0.1.18" }]
 
 [[package]]
 name = "dartbrains-tools"
-version = "0.1.2"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anywidget" },
@@ -583,9 +583,9 @@ dependencies = [
     { name = "scipy" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/a0/7e218a0751059cf64c7de491b9e18321240c0833608188673cb027521eee/dartbrains_tools-0.1.2.tar.gz", hash = "sha256:56dc3ffcb6d3e91709c8d47d79cecadbf362a5a1bdfcc63c618ff5ab19e6b760", size = 38781, upload-time = "2026-04-29T19:42:29.654Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/93/50171c5934828fc4c22558cfef4c57ce0b5ab15b101742e1747b9a1e3ec9/dartbrains_tools-0.1.4.tar.gz", hash = "sha256:6c47cc6ec6bdee4830e9eba115e7006c5e17e9850e1cd922ffa0a88b85521b17", size = 47273, upload-time = "2026-06-10T00:02:48.236Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/4e/6641e6c5677a9ce207db56ce0d2152811463e72c171c07884c6189075b4c/dartbrains_tools-0.1.2-py3-none-any.whl", hash = "sha256:fd2d6971e54294597d6a7c834db5651412d241ce6e257ad18ab868813432485b", size = 46255, upload-time = "2026-04-29T19:42:28.487Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e1/51ff4107f5562a3d192803681f4e7c8d7e17a195c90e86c55ce118a46d6f/dartbrains_tools-0.1.4-py3-none-any.whl", hash = "sha256:c01d630b078a1dfbeb41f5a85961d070114ad9b5c0f7e774079b322c1d39a4aa", size = 54344, upload-time = "2026-06-10T00:02:47.063Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Now that **dartbrains-tools 0.1.4** is released (with the `sherlock`/`paranoia` accessors and the `data/` subpackage refactor), this updates the book to use it.

- **`Download_Data.py`** — two new sections documenting the Sherlock and Paranoia naturalistic-fMRI datasets, now hosted on HuggingFace at `dartbrains/sherlock` and `dartbrains/paranoia`, demonstrating the `dartbrains_tools.data.{sherlock,paranoia}` accessors.
- **Localizer namespace migration** — all notebooks that used the flat `from dartbrains_tools.data import get_file, ...` API now use the explicit `from dartbrains_tools.data import localizer` namespace (`localizer.get_file(...)`, etc.), matching the new sherlock/paranoia style. Covers executable cells **and** prose code examples. Marimo cell signatures regenerated via `marimo check --fix`.
- Bumps the `dartbrains-tools` pin to `>=0.1.4` and updates `uv.lock`.

Migrated notebooks: Connectivity, Multivariate_Prediction, GLM_Single_Subject_Model, RSA, Introduction_to_Neuroimaging_Data, ICA, Download_Data, Group_Analysis, Thresholding_Group_Analyses.

## Notes

- The flat localizer API is still fully supported by dartbrains-tools (back-compat re-exports); this migration is for namespace clarity/consistency, not because anything broke.
- Validated each notebook with marimo's recomputed refs (no cell references a bare migrated name) and `ast.parse`. Not executed locally (BOLD downloads are large); the book CI exercises the cells.

## Test plan

- [ ] Book CI builds without errors (`uv sync --all-groups`, marimo-book build)
- [ ] New Sherlock + Paranoia sections render on the Download_Data page
- [ ] Existing localizer-based notebooks build with the new `localizer.` calls